### PR TITLE
Add model options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Follow these steps to set up VideoFck (by LordHaziza) on your local machine:
     *   **Windows:** Double-click the `setup.bat` file.
     *   **macOS/Linux:** Run `./setup.sh` in your terminal.
 
-    Follow the installation steps and add your api keys during the setup. (links to API keys for each platform provided during setup)
+    Follow the installation steps and add your API keys during the setup. The script also asks for `LLAMA_MODEL_PATH` if you want to use the local Llama3 model.
 
 3.  **Run the application:**
     *   **Windows:** Double-click `start.bat`
@@ -48,9 +48,10 @@ Before using VideoFck (by LordHaziza), ensure you have the following:
 *   **`pip`** (Python's package installer).
 *   **API Keys:**
     *   ElevenLabs API Key (if using ElevenLabs TTS).
-    *   OpenAI API Key (if using GPT model).
+    *   OpenAI API Key (if using GPT models).
     *   Claude API Key (if using Claude model).
     *   Gemini API Key.
+    *   Path to a local Llama 3 model file (set `LLAMA_MODEL_PATH` in `.env` if using the local model).
 ## Note: For using Google TTS You need to set your service account details and google api in the env file. More details here: https://cloud.google.com/text-to-speech/docs/authentication
 *   **Google Cloud SDK:** For Google Cloud TTS and you must install the Google Cloud SDK: [https://cloud.google.com/sdk/docs/install](https://cloud.google.com/sdk/docs/install), and have a [Google Service Account Key](https://cloud.google.com/iam/docs/keys-create-delete) which its path must be inserted when prompted (Optional). You can Always add it in ".env" file.
 
@@ -64,7 +65,7 @@ Before using VideoFck (by LordHaziza), ensure you have the following:
     *  **Number (recommended)**: extract a specific number of keyframes, evenly spaced in the video.
     *   Adjust `keyframes per segment` to control the number of keyframes that are given to the LLM for caption and narration generation.
 3.  **Model Settings:**
-    *   Choose between the **Claude** or **GPT** model for captions and narrations.
+    *   Choose between **Claude 3-5 Sonnet**, **Claude 3-7 Sonnet**, **GPT-4o**, **GPT-4.1**, **GPT-4.1-mini**, or **Llama3 (local)** for captions and narrations.
     *   Adjust playback speed and add style instructions.
 4.  **Text-to-Speech (TTS):** Select a TTS Engine (Google Cloud TTS or ElevenLabs), a voice, and model if using ElevenLabs.
 6.  **Original Audio Volume**: Change the original audio volume if needed, this is useful if you wish to keep the original audio with a low volume along with the generated narrations.

--- a/app.py
+++ b/app.py
@@ -157,7 +157,7 @@ def process_video(
         return "Error copying video file.", None, None, None, processing_state
 
     # Load prompts
-    if model_choice == "gpt":
+    if model_choice.lower().startswith("gpt"):
         with open("prompts/multi_image_segmented_prompt.txt", "r", encoding="utf-8") as f:
             base_caption_prompt = f.read().strip()
         base_tts_prompt = None
@@ -359,8 +359,15 @@ if __name__ == "__main__":
                             with gr.Row():
                                 model_choice_input = gr.Radio(
                                     label="Model Choice",
-                                    choices=["Claude", "gpt"],
-                                    value="Claude"
+                                    choices=[
+                                        "Claude 3-5 Sonnet",
+                                        "Claude 3-7 Sonnet",
+                                        "GPT-4o",
+                                        "GPT-4.1",
+                                        "GPT-4.1-mini",
+                                        "Llama3",
+                                    ],
+                                    value="Claude 3-5 Sonnet",
                                 )
                                 speed_factor_input = gr.Slider(
                                     label="Playback Speed",
@@ -417,7 +424,7 @@ if __name__ == "__main__":
                                 None,
                                 "eleven_flash_v2_5",
                                 None,
-                                "gpt",
+                                "GPT-4o",
                                 1.0,
                                 "make it funny",
                                 False,
@@ -429,7 +436,7 @@ if __name__ == "__main__":
                                 "ElevenLabs",
                                 None,
                                 "eleven_flash_v2_5",
-                                "gpt",
+                                "GPT-4o",
                                 1.0,
                                 "you are a FOULED MOUTH gangsta rapper using NONSTOP profanity",
                                 True,
@@ -442,7 +449,7 @@ if __name__ == "__main__":
                                 None,
                                 "eleven_flash_v2_5",
                                 None,
-                                "gpt",
+                                "GPT-4o",
                                 1.0,
                                 "you are a gangsta rapper using profanity",
                                 False,

--- a/config.py
+++ b/config.py
@@ -11,10 +11,13 @@ ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+LLAMA_MODEL_PATH = os.getenv("LLAMA_MODEL_PATH")
 
 def verify_api_keys():
     """Verify that all necessary API keys are set."""
     keys_present = True
     if not ELEVENLABS_API_KEY:
         print("Warning: ELEVENLABS_API_KEY not found. ElevenLabs TTS will not be available. TO SET KEYS, OPEN .env FILE")
+    if not LLAMA_MODEL_PATH:
+        print("Warning: LLAMA_MODEL_PATH not found. Local Llama model won't be available.")
     return keys_present

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ gradio
 ffmpeg-python
 openai-whisper
 torch
+llama-cpp-python

--- a/setup.sh
+++ b/setup.sh
@@ -77,6 +77,9 @@ prompt_and_write "CLAUDE_API_KEY" "Enter your Claude API key"
 # GEMINI_API_KEY
 prompt_and_write "GEMINI_API_KEY" "Enter your Gemini API key"
 
+# LLAMA_MODEL_PATH
+prompt_and_write "LLAMA_MODEL_PATH" "Enter the path to your local Llama model file (optional)"
+
 # GOOGLE_APPLICATION_CREDENTIALS (Optional, only prompted if gcloud SDK is installed)
 if command_exists gcloud; then
   prompt_and_write "GOOGLE_APPLICATION_CREDENTIALS" "Enter the full path to your Google Application Credentials JSON file (optional)"
@@ -100,6 +103,7 @@ ELEVENLABS_API_KEY = os.getenv("ELEVENLABS_API_KEY")
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 GOOGLE_APPLICATION_CREDENTIALS = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+LLAMA_MODEL_PATH = os.getenv("LLAMA_MODEL_PATH")
 
 def verify_api_keys():
     """Verify that all necessary API keys are set."""
@@ -113,6 +117,8 @@ def verify_api_keys():
         print("Warning: OPENAI_API_KEY not found. OpenAI services will not be available.")
     if not CLAUDE_API_KEY:
         print("Warning: CLAUDE_API_KEY not found. Claude services will not be available.")
+    if not LLAMA_MODEL_PATH:
+        print("Warning: LLAMA_MODEL_PATH not set. Local Llama model will not be available.")
     return keys_present
 EOF
 echo "config.py file created and populated"

--- a/utils/gemini_utils.py
+++ b/utils/gemini_utils.py
@@ -1,8 +1,9 @@
 import logging
 import os
-from config import CLAUDE_API_KEY, OPENAI_API_KEY
+from config import CLAUDE_API_KEY, OPENAI_API_KEY, LLAMA_MODEL_PATH
 import anthropic
 from openai import OpenAI
+from llama_cpp import Llama
 import time
 import datetime
 import re
@@ -30,15 +31,26 @@ def extract_timestamp(filename):
 # Initialize clients
 if CLAUDE_API_KEY:
     anthropic_client = anthropic.Anthropic(api_key=CLAUDE_API_KEY)
-    anthropic_model_name = "claude-3-5-sonnet-20241022"
 else:
     anthropic_client = None
-    anthropic_model_name = None
+
+# Default anthropic model; actual model may be overridden per request
+anthropic_model_name = "claude-3-5-sonnet-20241022"
 
 if OPENAI_API_KEY:
     openai_client = OpenAI(api_key=OPENAI_API_KEY)
 else:
     openai_client = None
+
+# Initialize local Llama model if path is provided
+if LLAMA_MODEL_PATH and os.path.exists(LLAMA_MODEL_PATH):
+    try:
+        llama_model = Llama(model_path=LLAMA_MODEL_PATH)
+    except Exception as e:
+        logging.error(f"Failed to load Llama model: {e}")
+        llama_model = None
+else:
+    llama_model = None
 
 def generate_captions_and_narrations(
     project_folder,
@@ -155,9 +167,10 @@ def generate_captions_and_narrations(
         return script_data, api_responses
 
     # ------------------------------------------------
-    # GPT-4o MULTI-IMAGE APPROACH (Modified for base64)
+    # GPT models MULTI-IMAGE APPROACH (Modified for base64)
     # ------------------------------------------------
-    if model_choice == "gpt":
+    if model_choice.lower().startswith("gpt"):
+        openai_model_name = model_choice
         if not openai_client:
             logging.error("OpenAI API key not found. Please set OPENAI_API_KEY in your environment.")
             return script_data, api_responses
@@ -221,12 +234,12 @@ def generate_captions_and_narrations(
             }
         ]
 
-        # Call GPT-4o a single time with all segment data
+        # Call the selected GPT model a single time with all segment data
         narration_response = ""
         for attempt in range(3):
             try:
                 response = openai_client.chat.completions.create(
-                    model="gpt-4o-2024-11-20",
+                    model=openai_model_name,
                     messages=messages,
                     max_tokens=2000,
                     temperature=0.6
@@ -235,7 +248,7 @@ def generate_captions_and_narrations(
                 if narration_response:
                     break
             except Exception as e:
-                logging.error(f"Error generating narration with GPT-4o: {e}, attempt {attempt+1}/3")
+                logging.error(f"Error generating narration with {openai_model_name}: {e}, attempt {attempt+1}/3")
                 if attempt < 2:
                     time.sleep(2)
 
@@ -274,9 +287,13 @@ def generate_captions_and_narrations(
             "prompt": combined_prompt
         })
 
-        logging.info("Generated script data with GPT-4o and style_instructions.")
+        logging.info(f"Generated script data with {openai_model_name} and style_instructions.")
 
-    elif model_choice == "Claude":
+    elif model_choice.lower().startswith("claude"):
+        if "3-7" in model_choice:
+            anthropic_model_name = "claude-3-7-sonnet-20241022"
+        else:
+            anthropic_model_name = "claude-3-5-sonnet-20241022"
         if not anthropic_client:
             logging.error("Claude API key not found. Please set CLAUDE_API_KEY in your environment.")
             return script_data, api_responses
@@ -407,7 +424,87 @@ def generate_captions_and_narrations(
             "prompt": combined_prompt
         })
 
-        logging.info("Generated script data with Claude and style_instructions.")
+        logging.info(f"Generated script data with {anthropic_model_name} and style_instructions.")
+
+    elif model_choice == "Llama3":
+        if not llama_model:
+            logging.error("Local Llama model not loaded. Please set LLAMA_MODEL_PATH in your environment.")
+            return script_data, api_responses
+
+        combined_prompt = (
+            f"{caption_prompt_input}\n\n"
+            "---------------------------------------------\n"
+            f"{style_instructions}\n"
+            "---------------------------------------------\n"
+            "For each segment described below provide your response in this format:\n"
+            "<BEGIN SEGMENT>\n"
+            "Frame Numbers: [frame_numbers]\n"
+            "Timestamp: start_time-end_time\n"
+            "Narration: your_narration_here\n"
+            "<END SEGMENT>\n"
+        )
+
+        for seg in segments:
+            seg_info = (
+                f"Segment Info:\n"
+                f"Frame Numbers: {seg['frame_numbers']}\n"
+                f"Timestamp: {seg['start_time']:.2f}-{seg['end_time']:.2f}\n"
+                f"Duration: {seg['duration']:.2f} seconds\n"
+                f"Max Words Allowed: {seg['max_words']}\n"
+            )
+            combined_prompt += seg_info
+
+        narration_response = ""
+        for attempt in range(3):
+            try:
+                resp = llama_model.create_completion(
+                    prompt=combined_prompt,
+                    max_tokens=2000,
+                    temperature=0.7,
+                )
+                narration_response = resp["choices"][0]["text"].strip()
+                if narration_response:
+                    break
+            except Exception as e:
+                logging.error(f"Error generating narration with Llama: {e}, attempt {attempt+1}/3")
+                if attempt < 2:
+                    time.sleep(2)
+
+        if not narration_response:
+            logging.error("Unable to generate narration with Llama after retries.")
+            return script_data, api_responses
+
+        segments_data = re.findall(
+            r"<BEGIN SEGMENT>\s*Frame Numbers:\s*\[(.*?)\]\s*Timestamp:\s*([\d\.]+)-([\d\.]+)\s*Narration:\s*(.*?)<END SEGMENT>",
+            narration_response,
+            re.DOTALL,
+        )
+
+        for seg_info in segments_data:
+            try:
+                frame_numbers = [int(num.strip()) for num in seg_info[0].split(',')]
+                start_time = float(seg_info[1])
+                end_time = float(seg_info[2])
+                narration = seg_info[3].strip().replace('\n', ' ')
+                matching_segment = next((s for s in segments if s["frame_numbers"] == frame_numbers), None)
+                if matching_segment:
+                    script_data.append({
+                        "frame_numbers": frame_numbers,
+                        "timestamp": f"{start_time:.2f}-{end_time:.2f}",
+                        "narration": narration,
+                        "OST": 2
+                    })
+            except Exception as e:
+                logging.error(f"Error processing segment data: {str(e)}")
+                continue
+
+        api_responses.append({
+            "segments": segments,
+            "narration": narration_response,
+            "prompt": combined_prompt
+        })
+
+        logging.info("Generated script data with Llama3.")
 
     else:
         logging.error(f"Unsupported model choice: {model_choice}")


### PR DESCRIPTION
## Summary
- document OpenAI and Claude model choices in README
- update UI to select Claude 3-5/3-7 Sonnet and GPT-4o/4.1/4.1-mini
- adapt prompt selection logic for GPT models
- support new model names when calling OpenAI and Claude APIs

## Testing
- `python -m py_compile app.py config.py utils/*.py`
